### PR TITLE
Revert "build(deps-dev): bump buffer from 5.7.1 to 6.0.3"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "boardgame.io": "^0.50.2",
-        "buffer": "^6.0.3",
+        "buffer": "^5.7.1",
         "parcel": "^2.8.3",
         "process": "^0.11.10",
         "react": "^18.2.0",
@@ -1855,9 +1855,9 @@
       }
     },
     "node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
       "dev": true,
       "funding": [
         {
@@ -1875,7 +1875,7 @@
       ],
       "dependencies": {
         "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/buffer-from": {
@@ -5595,13 +5595,13 @@
       }
     },
     "buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
       "dev": true,
       "requires": {
         "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
+        "ieee754": "^1.1.13"
       }
     },
     "buffer-from": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "homepage": "https://remarkablegames.org/tic-tac-toe/",
   "devDependencies": {
     "boardgame.io": "^0.50.2",
-    "buffer": "^6.0.3",
+    "buffer": "^5.7.1",
     "parcel": "^2.8.3",
     "process": "^0.11.10",
     "react": "^18.2.0",


### PR DESCRIPTION
Reverts remarkablegames/tic-tac-toe#1

```
@parcel/resolver-default: Could not find module "buffer" satisfying ^5.5.0.

  /Users/mark/Code/games/tic-tac-toe/package.json:15:5
    14 |     "boardgame.io": "^0.50.2",
  > 15 |     "buffer": "^6.0.3",
  >    |     ^^^^^^^^ Found this conflicting local requirement.
    16 |     "parcel": "^2.8.3",
    17 |     "process": "^0.11.10",
```